### PR TITLE
Add some base types to JSX.IntrinsicElements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "w3ts-jsx",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "JSX for Warcraft III maps",
   "author": "verit",
   "license": "ISC",

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -410,6 +410,40 @@ const setProp = (
 	}
 };
 
+const typeNames = [
+	"backdrop",
+	"button",
+	"chatdisplay",
+	"checkbox",
+	"control",
+	"dialog",
+	"editbox",
+	"gluebutton",
+	"gluecheckbox",
+	"glueeditbox",
+	"gluepopupmenu",
+	"gluetextbutton",
+	"highlight",
+	"listbox",
+	"menu",
+	"model",
+	"popupmenu",
+	"scrollbar",
+	"slashchatbox",
+	"slider",
+	"sprite",
+	"text",
+	"textarea",
+	"textbutton",
+	"timertext",
+];
+
+const simpleTypeNames = [
+	"simple-button",
+	"simple-checkbox",
+	"simple-statusbar",
+];
+
 export const adapter: Adapter<framehandle> = {
 	createFrame: (
 		jsxType: string,
@@ -417,14 +451,29 @@ export const adapter: Adapter<framehandle> = {
 		props: FrameProps,
 	) => {
 		let frame: framehandle;
+
 		const {
 			name = frameDefaults.name,
 			priority = frameDefaults.priority,
-			typeName,
 			inherits,
 			isSimple,
 			context = frameDefaults.context,
 		} = props;
+
+		let typeName = props.typeName;
+
+		if (typeName == null && typeNames.includes(jsxType))
+			typeName = jsxType.toUpperCase();
+
+		if (typeName == null && simpleTypeNames.includes(jsxType))
+			typeName = jsxType.replace("-", "").toUpperCase();
+
+		// frame is both our base component and a typeName; we expose it as
+		// container
+		if (typeName == null && jsxType === "container") typeName = "FRAME";
+		if (typeName == null && jsxType === "simple-container")
+			typeName = "SIMPLEFRAME";
+
 		if (isSimple ?? jsxType === "simple-frame")
 			frame = BlzCreateSimpleFrame(name, parentFrame, context);
 		else if (typeName)

--- a/src/test/__snapshots__/build.test.ts.snap
+++ b/src/test/__snapshots__/build.test.ts.snap
@@ -2652,6 +2652,8 @@ setProp = function(frame, prop, value, oldValue)
     end
     ::____switch21_end::
 end
+local typeNames = {\\"backdrop\\", \\"button\\", \\"chatdisplay\\", \\"checkbox\\", \\"control\\", \\"dialog\\", \\"editbox\\", \\"gluebutton\\", \\"gluecheckbox\\", \\"glueeditbox\\", \\"gluepopupmenu\\", \\"gluetextbutton\\", \\"highlight\\", \\"listbox\\", \\"menu\\", \\"model\\", \\"popupmenu\\", \\"scrollbar\\", \\"slashchatbox\\", \\"slider\\", \\"sprite\\", \\"text\\", \\"textarea\\", \\"textbutton\\", \\"timertext\\"}
+local simpleTypeNames = {\\"simple-button\\", \\"simple-checkbox\\", \\"simple-statusbar\\"}
 ____exports.adapter = {
     createFrame = function(____, jsxType, parentFrame, props)
         local frame
@@ -2663,12 +2665,26 @@ ____exports.adapter = {
         if priority == nil then
             priority = frameDefaults.priority
         end
-        local typeName = props.typeName
         local inherits = props.inherits
         local isSimple = props.isSimple
         local context = props.context
         if context == nil then
             context = frameDefaults.context
+        end
+        local typeName = props.typeName
+        if (typeName == nil) and __TS__ArrayIncludes(typeNames, jsxType) then
+            typeName = string.upper(jsxType)
+        end
+        if (typeName == nil) and __TS__ArrayIncludes(simpleTypeNames, jsxType) then
+            typeName = string.upper(
+                __TS__StringReplace(jsxType, \\"-\\", \\"\\")
+            )
+        end
+        if (typeName == nil) and (jsxType == \\"container\\") then
+            typeName = \\"FRAME\\"
+        end
+        if (typeName == nil) and (jsxType == \\"simple-container\\") then
+            typeName = \\"SIMPLEFRAME\\"
         end
         if (function(____lhs)
             if ____lhs == nil then

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -21,7 +21,8 @@ type AbsPos =
 
 type Handler = (() => void) | null;
 
-type FrameProps = {
+// Props shared by all frame types
+type CommonFrameProps = {
 	// immutable props
 	name?: string;
 	priority?: number;
@@ -45,13 +46,21 @@ type FrameProps = {
 	textAlignment?: { vert: textaligntype; horz: textaligntype };
 	textColor?: number;
 	texture?: { texFile?: string; flag?: number; blend?: boolean };
-	tooltip?: framehandle | null;
 	value?: number;
 	vertexColor?: number;
 	visible?: boolean;
 	size?: { width?: number; height?: number };
 	position?: Pos[] | null;
 	absPosition?: AbsPos[] | null;
+};
+
+type SimpleFrameProps = CommonFrameProps;
+
+type ComplexFrameProps = CommonFrameProps & {
+	tooltip?: framehandle | null;
+};
+
+type FrameProps = ComplexFrameProps & {
 	// events
 	onClick?: Handler;
 	onMouseEnter?: Handler;
@@ -71,13 +80,300 @@ type FrameProps = {
 	onEditboxEnter?: Handler;
 };
 
+type BackdropProps = ComplexFrameProps;
+
+type ButtonProps = ComplexFrameProps & {
+	// events
+	onClick?: Handler;
+	onMouseEnter?: Handler;
+	onMouseLeave?: Handler;
+	onMouseUp?: Handler;
+	onMouseDown?: Handler;
+	onMouseWheel?: Handler;
+	onDoubleClick?: Handler;
+};
+
+type ChatDisplayProps = ComplexFrameProps & {
+	// events
+	onClick?: Handler;
+	onMouseEnter?: Handler;
+	onMouseLeave?: Handler;
+	onMouseUp?: Handler;
+	onMouseDown?: Handler;
+	onMouseWheel?: Handler;
+	onDoubleClick?: Handler;
+};
+
+type CheckboxProps = ComplexFrameProps & {
+	// events
+	onClick?: Handler;
+	onMouseEnter?: Handler;
+	onMouseLeave?: Handler;
+	onMouseUp?: Handler;
+	onMouseDown?: Handler;
+	onMouseWheel?: Handler;
+	onCheckboxChecked?: Handler;
+	onCheckboxUnchecked?: Handler;
+	onDoubleClick?: Handler;
+};
+
+type ControlProps = ComplexFrameProps & {
+	// events
+	onMouseEnter?: Handler;
+	onMouseLeave?: Handler;
+	onMouseUp?: Handler;
+	onMouseDown?: Handler;
+};
+
+type DialogProps = ComplexFrameProps & {
+	// events
+	onDialogCancel?: Handler;
+	onDialogAccept?: Handler;
+};
+
+type EditBoxProps = ComplexFrameProps & {
+	// events
+	onClick?: Handler;
+	onMouseEnter?: Handler;
+	onMouseLeave?: Handler;
+	onMouseUp?: Handler;
+	onMouseDown?: Handler;
+	onMouseWheel?: Handler;
+	onEditboxTextChanged?: Handler;
+	onDoubleClick?: Handler;
+	onEditboxEnter?: Handler;
+};
+
+type ContainerProps = ComplexFrameProps;
+
+type GlueButtonProps = ComplexFrameProps & {
+	// events
+	onClick?: Handler;
+	onMouseEnter?: Handler;
+	onMouseLeave?: Handler;
+	onMouseUp?: Handler;
+	onMouseDown?: Handler;
+	onMouseWheel?: Handler;
+};
+
+type GlueCheckboxProps = ComplexFrameProps & {
+	// events
+	onClick?: Handler;
+	onMouseEnter?: Handler;
+	onMouseLeave?: Handler;
+	onMouseUp?: Handler;
+	onMouseDown?: Handler;
+	onMouseWheel?: Handler;
+	onCheckboxChecked?: Handler;
+	onCheckboxUnchecked?: Handler;
+	onDoubleClick?: Handler;
+};
+
+type GlueEditBoxProps = ComplexFrameProps & {
+	// events
+	onClick?: Handler;
+	onMouseEnter?: Handler;
+	onMouseLeave?: Handler;
+	onMouseUp?: Handler;
+	onMouseDown?: Handler;
+	onMouseWheel?: Handler;
+	onEditboxTextChanged?: Handler;
+	onDoubleClick?: Handler;
+	onEditboxEnter?: Handler;
+};
+
+type GluePopupMenuProps = ComplexFrameProps & {
+	// events
+	onClick?: Handler;
+	onMouseEnter?: Handler;
+	onMouseLeave?: Handler;
+	onMouseWheel?: Handler;
+	onPopupmenuItemChanged?: Handler;
+	onDoubleClick?: Handler;
+};
+
+type GlueTextButtonProps = ComplexFrameProps & {
+	// events
+	onClick?: Handler;
+	onMouseEnter?: Handler;
+	onMouseLeave?: Handler;
+	onMouseUp?: Handler;
+	onMouseDown?: Handler;
+	onMouseWheel?: Handler;
+	onDoubleClick?: Handler;
+};
+
+type HighlightProps = ComplexFrameProps;
+
+type ListBoxProps = ComplexFrameProps & {
+	// events
+	onMouseEnter?: Handler;
+	onMouseLeave?: Handler;
+	onMouseUp?: Handler;
+	onMouseDown?: Handler;
+	onMouseWheel?: Handler;
+};
+
+type MenuProps = ComplexFrameProps & {
+	// events
+	onMouseEnter?: Handler;
+	onMouseLeave?: Handler;
+	onMouseUp?: Handler;
+	onMouseDown?: Handler;
+	onMouseWheel?: Handler;
+};
+
+type ModelProps = ComplexFrameProps & {
+	// events
+	onMouseEnter?: Handler;
+	onMouseLeave?: Handler;
+	onMouseUp?: Handler;
+	onMouseDown?: Handler;
+	onMouseWheel?: Handler;
+};
+
+type PopupMenuProps = ComplexFrameProps & {
+	// events
+	onClick?: Handler;
+	onMouseEnter?: Handler;
+	onMouseLeave?: Handler;
+	onMouseWheel?: Handler;
+	onPopupmenuItemChanged?: Handler;
+	onDoubleClick?: Handler;
+};
+
+type ScrollbarProps = ComplexFrameProps & {
+	// events
+	onMouseEnter?: Handler;
+	onMouseLeave?: Handler;
+	onMouseUp?: Handler;
+	onMouseDown?: Handler;
+	onMouseWheel?: Handler;
+	onSliderChanged?: Handler;
+};
+
+type SimpleButtonProps = SimpleFrameProps & {
+	tooltip?: framehandle | null;
+	// events
+	onClick?: Handler;
+};
+
+type SimpleCheckboxProps = SimpleFrameProps;
+
+type SimpleContainerProps = SimpleFrameProps;
+
+type SimpleStatusBarProps = SimpleFrameProps;
+
+type SlashChatboxProps = ComplexFrameProps & {
+	// events
+	onClick?: Handler;
+	onMouseEnter?: Handler;
+	onMouseLeave?: Handler;
+	onMouseUp?: Handler;
+	onMouseDown?: Handler;
+	onMouseWheel?: Handler;
+	onEditboxTextChanged?: Handler;
+	onDoubleClick?: Handler;
+	onEditboxEnter?: Handler;
+};
+
+type SliderProps = ComplexFrameProps & {
+	// events
+	onClick?: Handler;
+	onMouseEnter?: Handler;
+	onMouseLeave?: Handler;
+	onMouseUp?: Handler;
+	onMouseDown?: Handler;
+	onMouseWheel?: Handler;
+	onSliderChanged?: Handler;
+	onDoubleClick?: Handler;
+};
+
+type SpriteProps = ComplexFrameProps & {
+	// events
+	onSpriteAnimUpdate?: Handler;
+};
+
+type TextProps = ComplexFrameProps & {
+	// events
+	onClick?: Handler;
+	onMouseEnter?: Handler;
+	onMouseLeave?: Handler;
+	onMouseUp?: Handler;
+	onMouseDown?: Handler;
+	onMouseWheel?: Handler;
+	onDoubleClick?: Handler;
+};
+
+type TextAreaProps = ComplexFrameProps & {
+	// events
+	onMouseEnter?: Handler;
+	onMouseLeave?: Handler;
+	onMouseUp?: Handler;
+	onMouseDown?: Handler;
+	onMouseWheel?: Handler;
+};
+
+type TextButtonProps = ComplexFrameProps & {
+	// events
+	onClick?: Handler;
+	onMouseEnter?: Handler;
+	onMouseLeave?: Handler;
+	onMouseUp?: Handler;
+	onMouseDown?: Handler;
+	onMouseWheel?: Handler;
+	onDoubleClick?: Handler;
+};
+
+type TimerTextProps = ComplexFrameProps & {
+	// events
+	onClick?: Handler;
+	onMouseEnter?: Handler;
+	onMouseLeave?: Handler;
+	onMouseUp?: Handler;
+	onMouseDown?: Handler;
+	onMouseWheel?: Handler;
+	onDoubleClick?: Handler;
+};
+
 declare namespace JSX {
 	interface IntrinsicElements {
 		frame: FrameProps;
 		"simple-frame": FrameProps;
+		backdrop: BackdropProps;
+		button: ButtonProps;
+		chatdisplay: ChatDisplayProps;
+		checkbox: CheckboxProps;
+		control: ControlProps;
+		dialog: DialogProps;
+		editbox: EditBoxProps;
+		container: ContainerProps;
+		gluebutton: GlueButtonProps;
+		gluecheckbox: GlueCheckboxProps;
+		glueeditbox: GlueEditBoxProps;
+		gluepopupmenu: GluePopupMenuProps;
+		gluetextbutton: GlueTextButtonProps;
+		heightlight: HighlightProps;
+		listbox: ListBoxProps;
+		menu: MenuProps;
+		model: ModelProps;
+		popupmenu: PopupMenuProps;
+		scrollbar: ScrollbarProps;
+		"simple-button": SimpleButtonProps;
+		"simple-checkbox": SimpleCheckboxProps;
+		"simple-container": SimpleContainerProps;
+		"simple-statusbar": SimpleStatusBarProps;
+		slashchatbox: SlashChatboxProps;
+		slider: SliderProps;
+		sprite: SpriteProps;
+		text: TextProps;
+		textarea: TextAreaProps;
+		textbutton: TextButtonProps;
+		timertext: TimerTextProps;
 	}
 }
 
+// Missing from war3-types
 declare function BlzFrameGetChildrenCount(frame: framehandle): number;
 declare function BlzFrameGetChild(
 	frame: framehandle,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -38,10 +38,7 @@ type CommonFrameProps = {
 	level?: number;
 	maxLength?: number;
 	minMaxValue?: { min?: number; max?: number };
-	model?: { modelFile?: string; cameraIndex?: number };
 	scale?: number;
-	spriteAnimate?: { primaryProp: number; flags: number };
-	stepSize?: number;
 	text?: string;
 	textAlignment?: { vert: textaligntype; horz: textaligntype };
 	textColor?: number;
@@ -54,14 +51,18 @@ type CommonFrameProps = {
 	absPosition?: AbsPos[] | null;
 };
 
+// Props shared by all simple frames
 type SimpleFrameProps = CommonFrameProps;
 
+// Props shared by all frames that are not simple frames
 type ComplexFrameProps = CommonFrameProps & {
 	tooltip?: framehandle | null;
 };
 
 type FrameProps = ComplexFrameProps & {
-	// events
+	model?: { modelFile?: string; cameraIndex?: number };
+	spriteAnimate?: { primaryProp: number; flags: number };
+	stepSize?: number;
 	onClick?: Handler;
 	onMouseEnter?: Handler;
 	onMouseLeave?: Handler;
@@ -83,7 +84,6 @@ type FrameProps = ComplexFrameProps & {
 type BackdropProps = ComplexFrameProps;
 
 type ButtonProps = ComplexFrameProps & {
-	// events
 	onClick?: Handler;
 	onMouseEnter?: Handler;
 	onMouseLeave?: Handler;
@@ -94,7 +94,6 @@ type ButtonProps = ComplexFrameProps & {
 };
 
 type ChatDisplayProps = ComplexFrameProps & {
-	// events
 	onClick?: Handler;
 	onMouseEnter?: Handler;
 	onMouseLeave?: Handler;
@@ -105,7 +104,6 @@ type ChatDisplayProps = ComplexFrameProps & {
 };
 
 type CheckboxProps = ComplexFrameProps & {
-	// events
 	onClick?: Handler;
 	onMouseEnter?: Handler;
 	onMouseLeave?: Handler;
@@ -118,7 +116,6 @@ type CheckboxProps = ComplexFrameProps & {
 };
 
 type ControlProps = ComplexFrameProps & {
-	// events
 	onMouseEnter?: Handler;
 	onMouseLeave?: Handler;
 	onMouseUp?: Handler;
@@ -126,13 +123,11 @@ type ControlProps = ComplexFrameProps & {
 };
 
 type DialogProps = ComplexFrameProps & {
-	// events
 	onDialogCancel?: Handler;
 	onDialogAccept?: Handler;
 };
 
 type EditBoxProps = ComplexFrameProps & {
-	// events
 	onClick?: Handler;
 	onMouseEnter?: Handler;
 	onMouseLeave?: Handler;
@@ -147,7 +142,6 @@ type EditBoxProps = ComplexFrameProps & {
 type ContainerProps = ComplexFrameProps;
 
 type GlueButtonProps = ComplexFrameProps & {
-	// events
 	onClick?: Handler;
 	onMouseEnter?: Handler;
 	onMouseLeave?: Handler;
@@ -157,7 +151,6 @@ type GlueButtonProps = ComplexFrameProps & {
 };
 
 type GlueCheckboxProps = ComplexFrameProps & {
-	// events
 	onClick?: Handler;
 	onMouseEnter?: Handler;
 	onMouseLeave?: Handler;
@@ -170,7 +163,6 @@ type GlueCheckboxProps = ComplexFrameProps & {
 };
 
 type GlueEditBoxProps = ComplexFrameProps & {
-	// events
 	onClick?: Handler;
 	onMouseEnter?: Handler;
 	onMouseLeave?: Handler;
@@ -183,7 +175,6 @@ type GlueEditBoxProps = ComplexFrameProps & {
 };
 
 type GluePopupMenuProps = ComplexFrameProps & {
-	// events
 	onClick?: Handler;
 	onMouseEnter?: Handler;
 	onMouseLeave?: Handler;
@@ -193,7 +184,6 @@ type GluePopupMenuProps = ComplexFrameProps & {
 };
 
 type GlueTextButtonProps = ComplexFrameProps & {
-	// events
 	onClick?: Handler;
 	onMouseEnter?: Handler;
 	onMouseLeave?: Handler;
@@ -206,7 +196,6 @@ type GlueTextButtonProps = ComplexFrameProps & {
 type HighlightProps = ComplexFrameProps;
 
 type ListBoxProps = ComplexFrameProps & {
-	// events
 	onMouseEnter?: Handler;
 	onMouseLeave?: Handler;
 	onMouseUp?: Handler;
@@ -215,7 +204,6 @@ type ListBoxProps = ComplexFrameProps & {
 };
 
 type MenuProps = ComplexFrameProps & {
-	// events
 	onMouseEnter?: Handler;
 	onMouseLeave?: Handler;
 	onMouseUp?: Handler;
@@ -224,7 +212,7 @@ type MenuProps = ComplexFrameProps & {
 };
 
 type ModelProps = ComplexFrameProps & {
-	// events
+	model?: { modelFile?: string; cameraIndex?: number };
 	onMouseEnter?: Handler;
 	onMouseLeave?: Handler;
 	onMouseUp?: Handler;
@@ -233,7 +221,6 @@ type ModelProps = ComplexFrameProps & {
 };
 
 type PopupMenuProps = ComplexFrameProps & {
-	// events
 	onClick?: Handler;
 	onMouseEnter?: Handler;
 	onMouseLeave?: Handler;
@@ -243,7 +230,7 @@ type PopupMenuProps = ComplexFrameProps & {
 };
 
 type ScrollbarProps = ComplexFrameProps & {
-	// events
+	stepSize?: number;
 	onMouseEnter?: Handler;
 	onMouseLeave?: Handler;
 	onMouseUp?: Handler;
@@ -254,7 +241,6 @@ type ScrollbarProps = ComplexFrameProps & {
 
 type SimpleButtonProps = SimpleFrameProps & {
 	tooltip?: framehandle | null;
-	// events
 	onClick?: Handler;
 };
 
@@ -265,7 +251,6 @@ type SimpleContainerProps = SimpleFrameProps;
 type SimpleStatusBarProps = SimpleFrameProps;
 
 type SlashChatboxProps = ComplexFrameProps & {
-	// events
 	onClick?: Handler;
 	onMouseEnter?: Handler;
 	onMouseLeave?: Handler;
@@ -278,7 +263,7 @@ type SlashChatboxProps = ComplexFrameProps & {
 };
 
 type SliderProps = ComplexFrameProps & {
-	// events
+	stepSize?: number;
 	onClick?: Handler;
 	onMouseEnter?: Handler;
 	onMouseLeave?: Handler;
@@ -290,12 +275,11 @@ type SliderProps = ComplexFrameProps & {
 };
 
 type SpriteProps = ComplexFrameProps & {
-	// events
+	spriteAnimate?: { primaryProp: number; flags: number };
 	onSpriteAnimUpdate?: Handler;
 };
 
 type TextProps = ComplexFrameProps & {
-	// events
 	onClick?: Handler;
 	onMouseEnter?: Handler;
 	onMouseLeave?: Handler;
@@ -306,7 +290,6 @@ type TextProps = ComplexFrameProps & {
 };
 
 type TextAreaProps = ComplexFrameProps & {
-	// events
 	onMouseEnter?: Handler;
 	onMouseLeave?: Handler;
 	onMouseUp?: Handler;
@@ -315,7 +298,6 @@ type TextAreaProps = ComplexFrameProps & {
 };
 
 type TextButtonProps = ComplexFrameProps & {
-	// events
 	onClick?: Handler;
 	onMouseEnter?: Handler;
 	onMouseLeave?: Handler;
@@ -326,7 +308,6 @@ type TextButtonProps = ComplexFrameProps & {
 };
 
 type TimerTextProps = ComplexFrameProps & {
-	// events
 	onClick?: Handler;
 	onMouseEnter?: Handler;
 	onMouseLeave?: Handler;


### PR DESCRIPTION
Defines all the base types and does automatic frameType mapping for you. Events are (maybe?) properly defined, but all properties are assume viable on all types (except a few ~obvious ones). Removing these will be type-breaking, but not functionality-breaking, so I'm fine with not incurring a breaking change to narrow them.